### PR TITLE
Configure RDS for AWS Free Tier compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,8 @@ terraform init
 terraform plan
 terraform apply
 ```
+
+## Nota de custo (Free Tier)
+
+Para compatibilidade com contas AWS Free Tier, o RDS esta configurado com `backup_retention_period = 0` nos ambientes `dev` e `prod`.
+Isso evita falhas como `FreeTierRestrictionError` relacionadas a retencao de backup.

--- a/infra/envs/dev/terraform.tfvars.example
+++ b/infra/envs/dev/terraform.tfvars.example
@@ -8,6 +8,7 @@ db_username             = "app_user"
 db_instance_class       = "db.t4g.micro"
 db_allocated_storage    = 20
 db_max_allocated_storage = 100
+db_backup_retention_period = 0
 
 container_environment = {
   APP_ENV = "dev"

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -149,7 +149,7 @@ variable "db_max_allocated_storage" {
 variable "db_backup_retention_period" {
   description = "Dias de retencao de backup do RDS"
   type        = number
-  default     = 1
+  default     = 0
 }
 
 variable "db_backup_window" {

--- a/infra/envs/prod/terraform.tfvars.example
+++ b/infra/envs/prod/terraform.tfvars.example
@@ -8,6 +8,7 @@ db_username             = "app_user"
 db_instance_class       = "db.t4g.small"
 db_allocated_storage    = 50
 db_max_allocated_storage = 300
+db_backup_retention_period = 0
 
 container_environment = {
   APP_ENV = "prod"

--- a/infra/envs/prod/variables.tf
+++ b/infra/envs/prod/variables.tf
@@ -149,7 +149,7 @@ variable "db_max_allocated_storage" {
 variable "db_backup_retention_period" {
   description = "Dias de retencao de backup do RDS"
   type        = number
-  default     = 7
+  default     = 0
 }
 
 variable "db_backup_window" {

--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -71,7 +71,7 @@ resource "aws_db_instance" "this" {
   db_subnet_group_name                = aws_db_subnet_group.this.name
   vpc_security_group_ids              = [aws_security_group.rds.id]
   backup_retention_period             = var.backup_retention_period
-  backup_window                       = var.backup_window
+  backup_window                       = var.backup_retention_period > 0 ? var.backup_window : null
   maintenance_window                  = var.maintenance_window
   auto_minor_version_upgrade          = true
   allow_major_version_upgrade         = false

--- a/infra/modules/rds/variables.tf
+++ b/infra/modules/rds/variables.tf
@@ -69,7 +69,7 @@ variable "max_allocated_storage" {
 variable "backup_retention_period" {
   description = "Dias de retencao de backup"
   type        = number
-  default     = 7
+  default     = 0
 }
 
 variable "backup_window" {


### PR DESCRIPTION
Set the backup retention period to 0 for RDS instances in both development and production environments to ensure compatibility with AWS Free Tier and prevent `FreeTierRestrictionError` related to backup retention. This change applies to the relevant Terraform configurations and variables.

Closes #11