### PR TITLE
Update deployment workflows for ECS and add manual apply/destroy

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -74,35 +74,95 @@ jobs:
           echo "image_uri=$IMAGE_URI" >> "$GITHUB_OUTPUT"
 
   deploy:
-    name: Terraform Apply (${{ needs.build_and_push.outputs.deploy_env }})
+    name: ECS Deploy (${{ needs.build_and_push.outputs.deploy_env }})
     runs-on: ubuntu-latest
     needs: build_and_push
     environment: ${{ needs.build_and_push.outputs.deploy_env }}
-    defaults:
-      run:
-        working-directory: infra/envs/${{ needs.build_and_push.outputs.deploy_env }}
     env:
-      TF_IN_AUTOMATION: "true"
-      TF_VAR_project_name: "aws-app-platform"
-      TF_VAR_container_image: ${{ needs.build_and_push.outputs.image_uri }}
+      AWS_REGION: us-east-1
+      PROJECT_NAME: aws-app-platform
+      DEPLOY_ENV: ${{ needs.build_and_push.outputs.deploy_env }}
+      CONTAINER_NAME: api
+      IMAGE_URI: ${{ needs.build_and_push.outputs.image_uri }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_wrapper: false
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::229371276586:role/github-actions-aws-app-platform
-          aws-region: us-east-1
+          aws-region: ${{ env.AWS_REGION }}
           mask-aws-account-id: true
 
-      - name: Terraform init
-        run: terraform init -input=false -reconfigure
+      - name: Resolve ECS target
+        id: ecs_target
+        shell: bash
+        run: |
+          CLUSTER_NAME="${PROJECT_NAME}-${DEPLOY_ENV}-cluster"
+          SERVICE_NAME="${PROJECT_NAME}-${DEPLOY_ENV}-service"
+          echo "cluster_name=${CLUSTER_NAME}" >> "$GITHUB_OUTPUT"
+          echo "service_name=${SERVICE_NAME}" >> "$GITHUB_OUTPUT"
 
-      - name: Terraform apply
-        run: terraform apply -input=false -auto-approve -no-color
+      - name: Deploy new task definition revision
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          CLUSTER_NAME="${{ steps.ecs_target.outputs.cluster_name }}"
+          SERVICE_NAME="${{ steps.ecs_target.outputs.service_name }}"
+
+          SERVICE_JSON="$(aws ecs describe-services --cluster "$CLUSTER_NAME" --services "$SERVICE_NAME")"
+          TASK_DEF_ARN="$(echo "$SERVICE_JSON" | jq -r '.services[0].taskDefinition')"
+
+          if [ -z "$TASK_DEF_ARN" ] || [ "$TASK_DEF_ARN" = "null" ]; then
+            echo "Task definition do service nao encontrada."
+            exit 1
+          fi
+
+          TASK_DEF_JSON="$(aws ecs describe-task-definition --task-definition "$TASK_DEF_ARN" --include TAGS)"
+          HAS_CONTAINER="$(echo "$TASK_DEF_JSON" | jq --arg NAME "$CONTAINER_NAME" '[.taskDefinition.containerDefinitions[] | select(.name == $NAME)] | length')"
+
+          if [ "$HAS_CONTAINER" -eq 0 ]; then
+            echo "Container '${CONTAINER_NAME}' nao encontrado na task definition atual."
+            exit 1
+          fi
+
+          NEW_CONTAINER_DEFS="$(echo "$TASK_DEF_JSON" | jq --arg IMG "$IMAGE_URI" --arg NAME "$CONTAINER_NAME" '
+            .taskDefinition.containerDefinitions
+            | map(if .name == $NAME then .image = $IMG else . end)
+          ')"
+
+          NEW_TASK_DEF_INPUT="$(echo "$TASK_DEF_JSON" | jq --argjson CONTAINERS "$NEW_CONTAINER_DEFS" '
+            .taskDefinition
+            | {
+                family,
+                taskRoleArn,
+                executionRoleArn,
+                networkMode,
+                containerDefinitions: $CONTAINERS,
+                volumes,
+                placementConstraints,
+                requiresCompatibilities,
+                cpu,
+                memory,
+                runtimePlatform,
+                ipcMode,
+                pidMode,
+                proxyConfiguration,
+                inferenceAccelerators,
+                ephemeralStorage
+              }
+          ')"
+
+          NEW_TASK_DEF_ARN="$(aws ecs register-task-definition --cli-input-json "$NEW_TASK_DEF_INPUT" | jq -r '.taskDefinition.taskDefinitionArn')"
+
+          aws ecs update-service \
+            --cluster "$CLUSTER_NAME" \
+            --service "$SERVICE_NAME" \
+            --task-definition "$NEW_TASK_DEF_ARN" \
+            --force-new-deployment > /dev/null
+
+          aws ecs wait services-stable --cluster "$CLUSTER_NAME" --services "$SERVICE_NAME"
+
+          echo "Deploy concluido: ${SERVICE_NAME} com imagem ${IMAGE_URI}"

--- a/.github/workflows/infra-apply-manual.yml
+++ b/.github/workflows/infra-apply-manual.yml
@@ -1,0 +1,75 @@
+name: Infra Apply Manual
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Ambiente para aplicar"
+        required: true
+        type: choice
+        options:
+          - dev
+          - prod
+      confirm:
+        description: "Digite APPLY para confirmar"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  apply:
+    name: Terraform Apply (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    defaults:
+      run:
+        working-directory: infra/envs/${{ inputs.environment }}
+    env:
+      TF_IN_AUTOMATION: "true"
+      TF_VAR_project_name: "aws-app-platform"
+      TF_VAR_container_image: "public.ecr.aws/nginx/nginx:stable"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate confirmation
+        shell: bash
+        run: |
+          if [ "${{ inputs.confirm }}" != "APPLY" ]; then
+            echo "Confirmacao invalida. Digite exatamente APPLY."
+            exit 1
+          fi
+          echo "Confirmacao recebida. Iniciando pipeline de apply para '${{ inputs.environment }}'."
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::229371276586:role/github-actions-aws-app-platform
+          aws-region: us-east-1
+          mask-aws-account-id: true
+
+      - name: Debug caller identity
+        run: aws sts get-caller-identity
+
+      - name: Terraform fmt (check)
+        run: terraform fmt -check -recursive ../..
+
+      - name: Terraform init
+        run: terraform init -input=false -reconfigure
+
+      - name: Terraform validate
+        run: terraform validate
+
+      - name: Terraform plan
+        run: terraform plan -input=false -no-color -out=tfplan
+
+      - name: Terraform apply
+        run: terraform apply -input=false -auto-approve -no-color tfplan

--- a/.github/workflows/infra-destroy.yml
+++ b/.github/workflows/infra-destroy.yml
@@ -1,0 +1,62 @@
+name: Infra Destroy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Ambiente para destruir"
+        required: true
+        type: choice
+        options:
+          - dev
+          - prod
+      confirm:
+        description: "Digite DESTROY para confirmar"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  destroy:
+    name: Terraform Destroy (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    defaults:
+      run:
+        working-directory: infra/envs/${{ inputs.environment }}
+    env:
+      TF_IN_AUTOMATION: "true"
+      TF_VAR_project_name: "aws-app-platform"
+      TF_VAR_container_image: "public.ecr.aws/nginx/nginx:stable"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate confirmation
+        shell: bash
+        run: |
+          if [ "${{ inputs.confirm }}" != "DESTROY" ]; then
+            echo "Confirmacao invalida. Digite exatamente DESTROY."
+            exit 1
+          fi
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::229371276586:role/github-actions-aws-app-platform
+          aws-region: us-east-1
+          mask-aws-account-id: true
+
+      - name: Terraform init
+        run: terraform init -input=false -reconfigure
+
+      - name: Terraform destroy
+        run: terraform destroy -input=false -auto-approve -no-color

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Guia de bootstrap do backend remoto:
 
 - `infra-plan.yml`: valida e gera plan de Terraform em PR.
 - `infra-apply.yml`: aplica infraestrutura em `main`.
-- `app-deploy.yml`: builda imagem de `app/`, publica no ECR e aplica Terraform com a nova `container_image`.
+- `app-deploy.yml`: builda imagem de `app/`, publica no ECR e faz deploy no ECS (nova revisao de task definition + update do service), sem executar Terraform.
 
 ## Nota de custo (Free Tier)
 


### PR DESCRIPTION
Enhance deployment workflows by integrating ECS deployment capabilities and introducing manual workflows for applying and destroying infrastructure. This update streamlines the deployment process and provides more control over infrastructure management.

Closes #19